### PR TITLE
Connect button does not display for connecting to pagbank account

### DIFF
--- a/pagbank-for-woocommerce.php
+++ b/pagbank-for-woocommerce.php
@@ -58,6 +58,20 @@ add_action(
 	ConnectAjaxApi::get_instance();
 	WebhookHandler::get_instance();
 
+	add_action('admin_notices', function () {
+		if (
+			!isset($_GET['page']) || strpos($_GET['page'], 'wc-settings') === false ||
+			!isset($_GET['section']) || $_GET['section'] !== 'pagbank_pix'
+		) {
+			return;
+		}
+	
+		$template = plugin_dir_path(__FILE__) . 'src/templates/connect-button-fix.php';
+		if (file_exists($template)) {
+			include $template;
+		}
+	});
+
 	if ( Helpers::is_wcfm_activated() ) {
 		WcfmIntegration::get_instance();
 	}

--- a/pagbank-for-woocommerce.php
+++ b/pagbank-for-woocommerce.php
@@ -61,7 +61,11 @@ add_action(
 	add_action('admin_notices', function () {
 		if (
 			!isset($_GET['page']) || strpos($_GET['page'], 'wc-settings') === false ||
-			!isset($_GET['section']) || $_GET['section'] !== 'pagbank_pix'
+			!isset($_GET['section']) || !in_array($_GET['section'], [
+				'pagbank_pix',
+				'pagbank_boleto',
+				'pagbank_credit_card'
+			])
 		) {
 			return;
 		}

--- a/src/templates/connect-button-fix.php
+++ b/src/templates/connect-button-fix.php
@@ -1,0 +1,24 @@
+<?php
+defined('ABSPATH') || exit;
+
+$env = get_option('woocommerce_pagbank_pix_environment', 'sandbox');
+$application_id = $env === 'production'
+	? '31241905-5426-4f88-a140-4416a2cab404'
+	: 'fa1553af-5f0c-4ff2-92c3-a0dd8984b6a1';
+
+$nonce = wp_create_nonce('pagbank_woocommerce_oauth');
+?>
+<div class="notice notice-info">
+	<h2>🔗 Conectar conta PagBank (botão alternativo fixo)</h2>
+	<p>Se o botão oficial não aparecer, use esse:</p>
+	<button
+		type="button"
+		class="button button-primary"
+		style="margin-top: 10px;"
+		data-connect-application-id="<?php echo esc_attr($application_id); ?>"
+		data-connect-application-environment="<?php echo esc_attr($env); ?>"
+		data-connect-nonce="<?php echo esc_attr($nonce); ?>"
+	>
+		Conectar com PagBank (<?php echo esc_html($env === 'production' ? 'Produção' : 'Sandbox'); ?>)
+	</button>
+</div>

--- a/src/ui/entries/admin/admin-settings.ts
+++ b/src/ui/entries/admin/admin-settings.ts
@@ -251,3 +251,40 @@ document.querySelectorAll("[data-connect-application-id]").forEach((connectButto
 		})();
 	});
 });
+
+setTimeout(() => {
+	const fakeInput = document.querySelector('input[type="pagbank_connect"]');
+	const notice = document.querySelector('.notice-info');
+  
+	if (fakeInput && notice) {
+	  const td = fakeInput.closest("td");
+  
+	  if (td) {
+		const jumpButton = document.createElement("button");
+		jumpButton.type = "button";
+		jumpButton.className = "button button-secondary";
+		jumpButton.style.marginTop = "5px";
+		jumpButton.textContent = "⚠ Clique aqui para conectar com o PagBank";
+  
+		jumpButton.addEventListener("click", () => {
+		  notice.scrollIntoView({ behavior: "smooth" });
+		  notice.style.boxShadow = "0 0 0 3px #007cba";
+		  setTimeout(() => {
+			notice.style.boxShadow = "none";
+		  }, 2000);
+  
+		  document.querySelectorAll('.notice:not(.notice-info)').forEach(n => n.remove());
+
+		  const infoNotices = document.querySelectorAll('.notice-info');
+		  infoNotices.forEach((n, i) => {
+			if (i > 0) n.remove();
+		  });
+		});
+  
+		td.innerHTML = "";
+		td.appendChild(jumpButton);
+	  }
+	}
+  }, 500);
+
+


### PR DESCRIPTION
Somehow the connect button does not display and a strange input shows where the button should show. This happens on all payment methods, as fallback, added a button on admin notices that work in that cases. Add a script to focus on it when this happens. The script clears other notices too.
![2025-03-30_22-11](https://github.com/user-attachments/assets/e1940634-dffc-4cda-a838-1d119bfcf7de)

![image](https://github.com/user-attachments/assets/a8f5b191-29a6-4abe-856f-16fa0665ccde)

Maybe there is another better solution for this case, but can solve the connect problem for anyone.